### PR TITLE
Added localStorage support for Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@ wall-display
 ============
 To compile the application (eg. on a Raspberry Pi with Raspbian/Wheezy) install QT4-dev:
 
-        apt-get install libqt4-dev libqtwebkit-dev qt4-qmake
+        apt-get install libqt4-dev libqtwebkit-dev qt4-qmake build-essential
 
 Build:
 
-        qmake
+        qmake # or qmake-qt4 on Ubuntu >= 16.04
         make
 
 Configure the application with the settings dialog
@@ -22,3 +22,5 @@ Or edit the config file in $HOME/.config/endocode/wall-display.conf:
 ```urls```: A comma separated list of urls to show.
 
 ```interval```: How many seconds every url should be displayed.
+
+Web applications like Grafana have to use [`LocalStorage`](http://doc.qt.io/qt-4.8/qwebsettings.html#localStoragePath) database. Application stores this data inside the `$HOME/.local/share/data/endocode/wall-display` path.

--- a/walldisplay.cpp
+++ b/walldisplay.cpp
@@ -35,6 +35,17 @@ WallDisplay::WallDisplay(QWidget *parent) :
     /* Load the first url */
     ui->webView->setUrl(QUrl(urls[0]));
 
+    QString homePath;
+    #if QT_VERSION >= 0x050000
+      homePath = QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    #else
+      homePath = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
+    #endif
+    QWebSettings* webSettings = ui->webView->settings();
+    webSettings->setAttribute(QWebSettings::LocalStorageEnabled, true);
+    webSettings->setOfflineStoragePath(homePath);
+    webSettings->enablePersistentStorage(homePath);
+
     /* start the timer with interval */
     connect(timer, SIGNAL(timeout()), this, SLOT(changeUrl()));
     timer->start(changeUrlInterval * 1000);

--- a/walldisplay.h
+++ b/walldisplay.h
@@ -5,6 +5,8 @@
 #include <QTimer>
 #include <QUrl>
 #include <QSettings>
+#include <QWebSettings>
+#include <QDesktopServices>
 #include <QDebug>
 #include <QKeyEvent>
 


### PR DESCRIPTION
Grafana (at least 3.x) doesn't work without localStorage. This PR fixes that.